### PR TITLE
initial textBox implementation

### DIFF
--- a/src/drawbot_skia/drawing.py
+++ b/src/drawbot_skia/drawing.py
@@ -5,6 +5,7 @@ import skia
 from .document import RecordingDocument
 from .errors import DrawbotError
 from .gstate import GraphicsState, GraphicsStateMixin
+from .font import getUPM, getAdvanceWidth
 
 
 class Drawing:
@@ -106,6 +107,44 @@ class Drawing:
             if self._flipCanvas:
                 self._canvas.scale(1, -1)
             self._drawItem(self._canvas.drawTextBlob, blob, 0, 0)
+
+    def textBox(self, txt, box, fontPath, align=None, boxFill=None):
+        # TODO: better/dedicated lineHeight, alignment, word breaks, 
+        # hyphenation, boxColor, 
+        #
+        # solve fontPath argument
+        #
+        # better lineWidth calcualtion : the last char on the line
+        # should be calculated by boundingBox, not advance width
+        #
+        # textCircle? textSkew? textTriangle? >> textPath..
+        
+        
+        currentFontSize = self.textSize("x")[1]
+        
+        # if boxFill:
+        #     with self.savedState():
+        #         GraphicsStateMixin.fill(*boxFill)
+        #         GraphicsStateMixin.rect(*box)
+        
+        x,y,w,h = box
+
+        while txt:
+            lineWidth = 0
+            lineText = ""
+            while lineWidth < w:
+                if txt:
+                    char = txt[0]
+                    lineWidth += getAdvanceWidth(char,fontPath, currentFontSize)
+                    if lineWidth < w:
+                        txt = txt[1:]  
+                        lineText+=char
+                else:
+                    # we're done.
+                    lineWidth=w
+                    txt=None
+            self.text(lineText,(x,h+y-currentFontSize))
+            self.translate(0,-currentFontSize)
 
     def image(self, imagePath, position, alpha=1.0):
         im = self._getImage(imagePath)

--- a/src/drawbot_skia/font.py
+++ b/src/drawbot_skia/font.py
@@ -1,5 +1,6 @@
 import struct
 from fontTools.ttLib import TTFont
+from defconAppKit.tools.textSplitter import splitText
 
 
 def makeTTFontFromSkiaTypeface(skTypeface):
@@ -38,3 +39,16 @@ def tagToInt(tag):
     if isinstance(tag, str):
         tag = bytes(tag, "ascii")
     return struct.unpack(">i", tag)[0]
+
+def getUPM(fontPath):
+    ftf = TTFont(fontPath)
+    if 'head' in ftf.keys():
+        return ftf['head'].unitsPerEm
+    # assume the common
+    return 1000
+
+def getAdvanceWidth(character, fontPath, fontSize=None):
+    ftf = TTFont(fontPath)
+    if not fontSize: fontSize=getUPM(fontPath)
+    gn = splitText(character,ftf['cmap'].getBestCmap())[0]
+    return ftf['hmtx'][gn][0]/getUPM(fontPath) * fontSize


### PR DESCRIPTION
It works. But still things to solve.

`textBox(txt, box, fontPath)`

The fontPath argument is ugly, I know. It is used to calculate the line width (TTFont['htmx']). Sure there is a nicer way.

known bugs / todo:
- text will go out of the box on the bottom, if the text is too long. 
- textBox don't respect words, it is all a string of characters.
- better/dedicated lineHeight
- alignment
- hyphenation
- boxColor, boxStroke
- solve fontPath argument
- better lineWidth calcualtion : the last char on the line should be calculated by boundingBox, not advance width
- textCircle? textSkew? textTriangle? >> textPath..
