### PR TITLE
made newPage functions to work without arguments too

### DIFF
--- a/src/drawbot_skia/drawing.py
+++ b/src/drawbot_skia/drawing.py
@@ -6,7 +6,9 @@ from .document import RecordingDocument
 from .errors import DrawbotError
 from .gstate import GraphicsState, GraphicsStateMixin
 
-default_canvas_dimensions = (1000, 1000)
+
+DEFAULT_CANVAS_DIMENSIONS = (1000, 1000)
+
 
 class Drawing:
 
@@ -25,7 +27,7 @@ class Drawing:
     @property
     def _canvas(self):
         if self._skia_canvas is None:
-            self.size(*default_canvas_dimensions)  # This will create the canvas
+            self.size(*DEFAULT_CANVAS_DIMENSIONS)  # This will create the canvas
         return self._skia_canvas
 
     @_canvas.setter
@@ -43,21 +45,16 @@ class Drawing:
             raise DrawbotError("size() can't be called if there's already a canvas active")
         self.newPage(width,  height)
 
-    def newPage(self, *dimensions):
-        assert len(dimensions) in (0, 2), (
-            "newPage() takes either no argument or two - width and height"
-            )
-        if dimensions:
-            width, height = dimensions
-        else:
+    def newPage(self, width=None, height=None):
+        if width and not height or height and not width:
+            raise TypeError("newPage() takes either no argument or two - width and height")
+        if not width and not height:
             width = getattr(self._document, 'pageWidth', None)
             height = getattr(self._document, 'pageHeight', None)
             if not width or not height:
-                # this is because dimensions are set only after drawing starts, 
+                # this is because dimensions are set only after drawing starts,
                 # if you use this function before, it breaks
-                width = default_canvas_dimensions[0]
-                height = default_canvas_dimensions[1]
-
+                width, height = DEFAULT_CANVAS_DIMENSIONS
         if self._document.isDrawing:
             self._document.endPage()
             self._gstate = GraphicsState()

--- a/src/drawbot_skia/drawing.py
+++ b/src/drawbot_skia/drawing.py
@@ -46,12 +46,12 @@ class Drawing:
         self.newPage(width,  height)
 
     def newPage(self, width=None, height=None):
-        if width and not height or height and not width:
+        if (width is not None and height is None) or (height is not None and width is None):
             raise TypeError("newPage() takes either no argument or two - width and height")
-        if not width and not height:
+        if width is None and height is None:
             width = getattr(self._document, 'pageWidth', None)
             height = getattr(self._document, 'pageHeight', None)
-            if not width or not height:
+            if width is None or height is None:
                 # this is because dimensions are set only after drawing starts,
                 # if you use this function before, it breaks
                 width, height = DEFAULT_CANVAS_DIMENSIONS

--- a/src/drawbot_skia/drawing.py
+++ b/src/drawbot_skia/drawing.py
@@ -6,6 +6,7 @@ from .document import RecordingDocument
 from .errors import DrawbotError
 from .gstate import GraphicsState, GraphicsStateMixin
 
+default_canvas_dimensions = (1000, 1000)
 
 class Drawing:
 
@@ -24,7 +25,7 @@ class Drawing:
     @property
     def _canvas(self):
         if self._skia_canvas is None:
-            self.size(1000, 1000)  # This will create the canvas
+            self.size(*default_canvas_dimensions)  # This will create the canvas
         return self._skia_canvas
 
     @_canvas.setter
@@ -42,7 +43,13 @@ class Drawing:
             raise DrawbotError("size() can't be called if there's already a canvas active")
         self.newPage(width,  height)
 
-    def newPage(self, width, height):
+    def newPage(self, *dimensions):
+        if dimensions:
+            width, height = dimensions
+        else:
+            width = getattr(self._document, 'pageWidth', default_canvas_dimensions[0])
+            height = getattr(self._document, 'pageHeight', default_canvas_dimensions[1])
+
         if self._document.isDrawing:
             self._document.endPage()
             self._gstate = GraphicsState()

--- a/src/drawbot_skia/drawing.py
+++ b/src/drawbot_skia/drawing.py
@@ -44,11 +44,19 @@ class Drawing:
         self.newPage(width,  height)
 
     def newPage(self, *dimensions):
+        assert len(dimensions) in (0, 2), (
+            "newPage() takes either no argument or two - width and height"
+            )
         if dimensions:
             width, height = dimensions
         else:
-            width = getattr(self._document, 'pageWidth', default_canvas_dimensions[0])
-            height = getattr(self._document, 'pageHeight', default_canvas_dimensions[1])
+            width = getattr(self._document, 'pageWidth', None)
+            height = getattr(self._document, 'pageHeight', None)
+            if not width or not height:
+                # this is because dimensions are set only after drawing starts, 
+                # if you use this function before, it breaks
+                width = default_canvas_dimensions[0]
+                height = default_canvas_dimensions[1]
 
         if self._document.isDrawing:
             self._document.endPage()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -148,6 +148,24 @@ def test_newPage_newGState():
     fill(1)
     assert (255, 255, 255, 255) == db._gstate.fillPaint.color
 
+def test_newPage_dimensions_arguments():
+    from drawbot_skia.drawing import default_canvas_dimensions
+    db = Drawing()
+    db.rect(0, 0, 300, 300) # the dimensions are set only after drawing starts
+    assert (db.width(), db.height()) == default_canvas_dimensions, (
+        "No args and first page - dimensions differ"
+        )
+    db.newPage(600, 450)
+    db.rect(0, 0, 300, 300)
+    assert (db.width(), db.height()) == (600, 450), (
+        "Args setting dimensions - dimensions differ"
+        )
+    db.newPage()
+    db.rect(0, 0, 300, 300)
+    assert (db.width(), db.height()) == (600, 450), (
+        "No args but not first page - dimensions differ" 
+        )
+
 
 def test_multipleDocuments(tmpdir):
     tmpdir = pathlib.Path(tmpdir)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -148,23 +148,24 @@ def test_newPage_newGState():
     fill(1)
     assert (255, 255, 255, 255) == db._gstate.fillPaint.color
 
+
 def test_newPage_dimensions_arguments():
-    from drawbot_skia.drawing import default_canvas_dimensions
+    from drawbot_skia.drawing import DEFAULT_CANVAS_DIMENSIONS
     db = Drawing()
-    db.rect(0, 0, 300, 300) # the dimensions are set only after drawing starts
-    assert (db.width(), db.height()) == default_canvas_dimensions, (
-        "No args and first page - dimensions differ"
-        )
+    db.rect(0, 0, 300, 300)  # the dimensions are set only after drawing starts
+    assert (db.width(), db.height()) == DEFAULT_CANVAS_DIMENSIONS
     db.newPage(600, 450)
     db.rect(0, 0, 300, 300)
-    assert (db.width(), db.height()) == (600, 450), (
-        "Args setting dimensions - dimensions differ"
-        )
+    assert (db.width(), db.height()) == (600, 450)
     db.newPage()
     db.rect(0, 0, 300, 300)
-    assert (db.width(), db.height()) == (600, 450), (
-        "No args but not first page - dimensions differ" 
-        )
+    assert (db.width(), db.height()) == (600, 450)
+    with pytest.raises(TypeError):
+        db.newPage(10)
+    with pytest.raises(TypeError):
+        db.newPage(width=10)
+    with pytest.raises(TypeError):
+        db.newPage(height=10)
 
 
 def test_multipleDocuments(tmpdir):


### PR DESCRIPTION
I made the `newPage` function to work without arguments too. 

```
    Initial newPage() without arguments: 1000 x 1000
    Second newPage() without arguments: same as previous page
```

I found an issue that the function throws an error if you don't draw before. Probably because RecordingDocument's `        self.pageWidth = self.pageHeight = None` Drawing makes it somehow become not None. It got a temporary fix